### PR TITLE
Enable AWS Performance Insights for the SUMO database

### DIFF
--- a/k8s/tf/70_prod_db_redis/main.tf
+++ b/k8s/tf/70_prod_db_redis/main.tf
@@ -1,13 +1,3 @@
-module "redis-shared" {
-  source                = "./redis"
-  redis_name            = "shared"
-  redis_node_size       = "cache.m3.large"
-  redis_num_nodes       = 3
-  nodes_security_groups = join(",", data.aws_security_groups.kops_sg.ids)
-  redis_subnet          = data.terraform_remote_state.vpc.outputs.redis_subnet_group
-}
-
-
 module "redis-test" {
   source                = "./redis"
   redis_name            = "test"
@@ -34,10 +24,12 @@ module "mysql-prod" {
   mysql_security_group_name   = "sumo_rds_sg_prod"
   mysql_storage_gb            = 250
   mysql_storage_type          = "gp2"
+  mysql_engine_version = {
+    mysql = "5.6.51"
+  }
 
   db_subnet_group = data.terraform_remote_state.vpc.outputs.db_subnet_group
   vpc_id          = data.terraform_remote_state.vpc.outputs.vpc_id
   vpc_cidr        = data.terraform_remote_state.vpc.outputs.cidr_block
   it_vpn_cidr     = var.it_vpn_cidr
 }
-

--- a/k8s/tf/70_prod_db_redis/rds-multi-az/rds-multi-az.tf
+++ b/k8s/tf/70_prod_db_redis/rds-multi-az/rds-multi-az.tf
@@ -5,29 +5,30 @@ resource "aws_kms_key" "key" {
 }
 
 resource "aws_db_instance" "sumo_rds" {
-  allocated_storage           = var.mysql_storage_gb
-  allow_major_version_upgrade = var.mysql_allow_major_version_upgrade
-  auto_minor_version_upgrade  = var.mysql_auto_minor_version_upgrade
-  backup_retention_period     = var.mysql_backup_retention_days
-  backup_window               = var.mysql_backup_window
-  db_subnet_group_name        = var.db_subnet_group
-  depends_on                  = [aws_security_group.sumo_rds_sg]
-  engine                      = var.mysql_engine
-  engine_version              = var.mysql_engine_version[var.mysql_engine]
-  identifier                  = var.mysql_identifier
-  instance_class              = var.mysql_instance_class
-  maintenance_window          = var.mysql_maintenance_window
-  multi_az                    = true
-  name                        = var.mysql_db_name
-  password                    = var.mysql_password
-  publicly_accessible         = false
-  storage_encrypted           = var.mysql_storage_encrypted
-  storage_type                = var.mysql_storage_type
-  username                    = var.mysql_username
-  vpc_security_group_ids      = [aws_security_group.sumo_rds_sg.id]
-  final_snapshot_identifier   = "sumo-final-db-snapshot"
-  kms_key_id                  = aws_kms_key.key.arn
-  deletion_protection         = true
+  allocated_storage            = var.mysql_storage_gb
+  allow_major_version_upgrade  = var.mysql_allow_major_version_upgrade
+  auto_minor_version_upgrade   = var.mysql_auto_minor_version_upgrade
+  backup_retention_period      = var.mysql_backup_retention_days
+  backup_window                = var.mysql_backup_window
+  db_subnet_group_name         = var.db_subnet_group
+  depends_on                   = [aws_security_group.sumo_rds_sg]
+  engine                       = var.mysql_engine
+  engine_version               = var.mysql_engine_version[var.mysql_engine]
+  identifier                   = var.mysql_identifier
+  instance_class               = var.mysql_instance_class
+  maintenance_window           = var.mysql_maintenance_window
+  multi_az                     = true
+  name                         = var.mysql_db_name
+  password                     = var.mysql_password
+  publicly_accessible          = false
+  storage_encrypted            = var.mysql_storage_encrypted
+  storage_type                 = var.mysql_storage_type
+  username                     = var.mysql_username
+  vpc_security_group_ids       = [aws_security_group.sumo_rds_sg.id]
+  final_snapshot_identifier    = "sumo-final-db-snapshot"
+  kms_key_id                   = aws_kms_key.key.arn
+  deletion_protection          = true
+  performance_insights_enabled = true
 
   enabled_cloudwatch_logs_exports = [
     "error",
@@ -71,4 +72,3 @@ resource "aws_security_group" "sumo_rds_sg" {
     "Environment" = "prod"
   }
 }
-

--- a/k8s/tf/70_prod_db_redis/redis/redis.tf
+++ b/k8s/tf/70_prod_db_redis/redis/redis.tf
@@ -7,6 +7,7 @@ resource "aws_elasticache_replication_group" "sumo-redis-rg" {
   parameter_group_name          = var.redis_param_group
   engine_version                = var.redis_engine_version
   automatic_failover_enabled    = var.redis_failover
+  multi_az_enabled              = var.multi_az_enabled
 
   subnet_group_name  = var.redis_subnet
   security_group_ids = split(",", var.nodes_security_groups)
@@ -19,4 +20,3 @@ resource "aws_elasticache_replication_group" "sumo-redis-rg" {
     "Environment" = "prod"
   }
 }
-

--- a/k8s/tf/70_prod_db_redis/redis/variables.tf
+++ b/k8s/tf/70_prod_db_redis/redis/variables.tf
@@ -29,3 +29,7 @@ variable "redis_subnet" {
 variable "redis_failover" {
   default = false
 }
+
+variable "multi_az_enabled" {
+  default = true
+}


### PR DESCRIPTION
The first commit in this PR makes the Terraform code match the reality of currently deployed RDS and Redis instances. This means I needed to remove the Redis instance called "sumo-redis-shared", which does not exist in the account, and only keep the instance named "sumo-redis-test", which for some reason appears to be the Redis instance used both in prod and the (mostly unused) dev environment, but not in stage. Of course this is a royal mess, but for now my goal is to make the code match the reality.

The second commit then enables Performance Insights. Since I already did that manually in the AWS console, running `terraform plan` shows no diff. I used Terraform version 0.13.7.

Note that the variable `mysql_prod_password` is undefined, so I had to run `terraform state pull` to retrieve the current value and use `export TF_VAR_mysql_prod_password="…"` to pass that value back to Terraform.

In related notes, the format generated by `terraform fmt` creates stupid diffs. I could add an empty line to make the diff less stupid, but I don't want to add an empty line. I want `terraform fmt` to be less stupid, though I know it's too late now.