### PR TITLE
Make the database accessible from Cloud SQL.

### DIFF
--- a/k8s/tf/00_aws-vpc/us-west-2/main.tf
+++ b/k8s/tf/00_aws-vpc/us-west-2/main.tf
@@ -2,7 +2,7 @@
 
 provider "aws" {
   region  = var.region
-  version = "~> 2"
+  version = "~> 3"
 }
 
 terraform {
@@ -29,6 +29,14 @@ module "vpc" {
   enable_nat_gateway = true
   single_nat_gateway = true
 
+  # Enable public access to the database subnets
+  create_database_subnet_group           = true
+  create_database_subnet_route_table     = true
+  create_database_internet_gateway_route = true
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
   # For VPN
   enable_vpn_gateway                 = true
   propagate_private_route_tables_vgw = true
@@ -47,7 +55,8 @@ module "vpc" {
   )
   public_subnet_tags = merge(
     {
-      "Purpose" = "kubernetes"
+      "Purpose"                                  = "kubernetes"
+      "kubernetes.io/cluster/sumo-eks-us-west-2" = "shared"
     },
     var.base_tags,
   )
@@ -120,4 +129,3 @@ resource "aws_customer_gateway" "mdc2" {
     var.base_tags,
   )
 }
-

--- a/k8s/tf/70_prod_db_redis/main.tf
+++ b/k8s/tf/70_prod_db_redis/main.tf
@@ -32,4 +32,5 @@ module "mysql-prod" {
   vpc_id          = data.terraform_remote_state.vpc.outputs.vpc_id
   vpc_cidr        = data.terraform_remote_state.vpc.outputs.cidr_block
   it_vpn_cidr     = var.it_vpn_cidr
+  cloud_sql_cidr  = var.cloud_sql_cidr
 }

--- a/k8s/tf/70_prod_db_redis/rds-multi-az/rds-multi-az.tf
+++ b/k8s/tf/70_prod_db_redis/rds-multi-az/rds-multi-az.tf
@@ -20,7 +20,7 @@ resource "aws_db_instance" "sumo_rds" {
   multi_az                     = true
   name                         = var.mysql_db_name
   password                     = var.mysql_password
-  publicly_accessible          = false
+  publicly_accessible          = true
   storage_encrypted            = var.mysql_storage_encrypted
   storage_type                 = var.mysql_storage_type
   username                     = var.mysql_username
@@ -54,7 +54,7 @@ resource "aws_security_group" "sumo_rds_sg" {
     from_port   = var.mysql_port
     to_port     = var.mysql_port
     protocol    = "TCP"
-    cidr_blocks = [var.vpc_cidr, var.it_vpn_cidr]
+    cidr_blocks = [var.vpc_cidr, var.it_vpn_cidr, var.cloud_sql_cidr]
   }
 
   egress {

--- a/k8s/tf/70_prod_db_redis/rds-multi-az/variables.tf
+++ b/k8s/tf/70_prod_db_redis/rds-multi-az/variables.tf
@@ -85,3 +85,6 @@ variable "db_subnet_group" {
 variable "it_vpn_cidr" {
 }
 
+variable "cloud_sql_cidr" {
+  description = "IP address of Cloud SQL replica"
+}

--- a/k8s/tf/70_prod_db_redis/variables.tf
+++ b/k8s/tf/70_prod_db_redis/variables.tf
@@ -10,3 +10,6 @@ variable "it_vpn_cidr" {
 variable "mysql_prod_password" {
 }
 
+variable "cloud_sql_cidr" {
+  default = "34.72.95.189/32"
+}


### PR DESCRIPTION
* Add subnet group to the database VPC subnets and configure them to route traffic to the public internet.
* Enable DNS support for the database subnets.
* Configure the database to be "publicly" accessible.
* Configure the database security group to allow traffic from the Cloud SQL instance.

Overall, this configure the database to be more open to the internet. Since there is only a single public IP address the security group is allowing traffic from, I think it's still fine.

The alternative would be to set up a VPN between AWS and GCP, which would be a lot more involved than the changes here.