### PR TITLE
Circleci s3 user

### DIFF
--- a/k8s/tf/50_cdn/static_media_s3/static_media_s3.tf
+++ b/k8s/tf/50_cdn/static_media_s3/static_media_s3.tf
@@ -1,6 +1,5 @@
 resource "aws_s3_bucket" "sumo-static-media" {
   bucket = var.bucket_name
-  region = var.region
   acl    = "log-delivery-write"
 
   force_destroy = false
@@ -55,4 +54,3 @@ resource "aws_s3_bucket" "sumo-static-media" {
 EOF
 
 }
-

--- a/k8s/tf/50_cdn/user_media_s3/user_media_s3.tf
+++ b/k8s/tf/50_cdn/user_media_s3/user_media_s3.tf
@@ -1,6 +1,5 @@
 resource "aws_s3_bucket" "sumo-user-media" {
   bucket = var.bucket_name
-  region = var.region
   acl    = "log-delivery-write"
 
   force_destroy = false
@@ -90,4 +89,3 @@ resource "aws_iam_user_policy_attachment" "user-media" {
   user       = aws_iam_user.user-media.name
   policy_arn = aws_iam_policy.user-media.arn
 }
-


### PR DESCRIPTION
This adds an IAM user with permissions to run `aws s3 sync --acl ...` to update static assets in S3. This is meant to be a temporary solution. It's possible we don't need the `DeleteObject` permission.

This script is used to upload static assets: https://github.com/mozilla/kitsune/blob/master/docker/bin/upload-staticfiles.sh

The Terraform has already been applied. Here's the diff:
```
  # aws_iam_policy.circleci-s3-user will be created
  + resource "aws_iam_policy" "circleci-s3-user" {
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = "circleci-s3-user-s3-sync"
      + path      = "/"
      + policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "s3:PutObjectAcl",
                          + "s3:PutObject",
                          + "s3:ListBucket",
                          + "s3:GetObject",
                          + "s3:GetBucketLocation",
                          + "s3:DeleteObject",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::mozit-sumo-stage-media/*",
                          + "arn:aws:s3:::mozit-sumo-stage-media",
                          + "arn:aws:s3:::mozit-sumo-prod-media/*",
                          + "arn:aws:s3:::mozit-sumo-prod-media",
                        ]
                      + Sid      = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id = (known after apply)
      + tags_all  = (known after apply)
    }

  # aws_iam_user.circleci-s3-user will be created
  + resource "aws_iam_user" "circleci-s3-user" {
      + arn           = (known after apply)
      + force_destroy = false
      + id            = (known after apply)
      + name          = "static-s3-user-circleci"
      + path          = "/"
      + tags_all      = (known after apply)
      + unique_id     = (known after apply)
    }

  # aws_iam_user_policy_attachment.circleci-s3-user will be created
  + resource "aws_iam_user_policy_attachment" "circleci-s3-user" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + user       = "static-s3-user-circleci"
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```