### PR TITLE
Add Monitoring to DNS health check prod-oregon.sumo.mozit.cloud endpoint

### DIFF
--- a/k8s/tf/200_single_state/us-west-2/.terraform.lock.hcl
+++ b/k8s/tf/200_single_state/us-west-2/.terraform.lock.hcl
@@ -2,21 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.73.0"
+  version     = "3.74.2"
   constraints = ">= 2.23.0, ~> 3.0, >= 3.56.0"
   hashes = [
-    "h1:ntQzWbRPf6wPXY/EqKN0AwTRYquGV5ey+tMey5/i8SM=",
-    "zh:04a2203758c8992ef4b70d5a0163294063fd3ddd9570db1101150717c274e7d9",
-    "zh:2f9f1b02a7f8a5aa01fbef5d155125658b62f60ec35bcae64f4314ef4a920922",
-    "zh:3f5befc947e76cd39eb52c66a3be5a916f24c814995c4364fa9394739efd5388",
-    "zh:416d352241369a9ed14a919e56bcf45de0e4759c2af7efd58b41a5669908f4ea",
-    "zh:4ed34ac4bf9894917a7a0e7e3886a9971e995e1b67762eb8a4bebeb848a88ad0",
-    "zh:553c6979620eb31aba29c669c46c3f8d0f6e55aa5c5b786e9dbe44e1868e8fca",
-    "zh:604add93fd89dd1ff388057a2ecd9bcc9325a14b28d4e04b1f97a498ac9caf1f",
-    "zh:7399cee513a6ef15ae97c17f5d09e1bb56f37d11dbbb330abb6c726abd2c6052",
-    "zh:915d132dc624fe0a141e4774ec853522d1ff355770e97ff5f2e7ad3c4295a8aa",
-    "zh:9e70a50d797308f0de4c2c1929a54893790b911a4cae33073aadc698004ea733",
-    "zh:f0a40289b271548d676e1e8b00eaf483b114f93d939e6ccf653d583cddc5961d",
+    "h1:gyAOih3vXIcMuixQQSbUZWS2cRDcYmEwOc01/ATpuoo=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
   ]
 }
 
@@ -59,21 +59,21 @@ provider "registry.terraform.io/hashicorp/helm" {
 }
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
-  version     = "2.7.1"
+  version     = "2.8.0"
   constraints = ">= 1.11.1, ~> 2.0"
   hashes = [
-    "h1:/zifejk3MfLSDQr5J6sc3EHrnFwAVEDH9LrewWMRqe4=",
-    "zh:0da320fd81ece6696f7cceda35e459ee97cae8955088af38fc7f2feab1dce924",
-    "zh:37d304b8b992518c9c12e8f10437b9d4a0cc5a823c9421ac794ad2347c4d1122",
-    "zh:3d4e12fb9588c3b2e782d392fea758c6982e5d653154bec951e949155bcbc169",
-    "zh:6bb32b8d5cccf3e3ae7c124ed27df76dc7653ca760c132addeee15272630c930",
-    "zh:94775153b90e285876fc17261e8f5338a1ff732f4133336cc68754acb74570b6",
-    "zh:a665d1336765cdf8620a8797fd4e7e3cecf789e96e59ba80634336a4390df377",
-    "zh:aa8b35e9958cb89f01c115e8866a07d5468fb53f1c227d673e94f7ee8fb76242",
-    "zh:b7a571336387d773a74ed6eefa3843ff78d3662f2745c99c95008002a1341662",
-    "zh:c50d661782175d50ea4952fe943b0e4a3e33c27aa69e5ff21b3cbfa513e90d0a",
-    "zh:e0999b349cc772c75876adbc2a13b5dc256d3ecd7e4aa91baee5fdfcecaa7465",
-    "zh:e1399aec06a7aa98e9b0f64b4281697247f338a8a40b79f5f6ebfd43bf4ce1e2",
+    "h1:tfU8BStZIt2d6KIGTRNjWb09zeVzh3UFGNRGVgFce+A=",
+    "zh:0cf42c17c05ae5f0f5eb4b2c375dd2068960b97392e50823e47b2cee7b5e01be",
+    "zh:29e3751eceae92c7400a17fe3a5394ed761627bcadfda66e7ac91d6485c37927",
+    "zh:2d95584504c651e1e2e49fbb5fae1736e32a505102c3dbd2c319b26884a7d3d5",
+    "zh:4a5f1d915c19e7c7b4f04d7d68f82db2c872dad75b9e6f33a6ddce43aa160405",
+    "zh:4b959187fd2c884a4c6606e1c4edc7b506ec4cadb2742831f37aca1463eb349d",
+    "zh:5e76a2b81c93d9904d50c2a703845f79d2b080c2f87c07ef8f168592033d638f",
+    "zh:c5aa21a7168f96afa4b4776cbd7eefd3e1f47d48430dce75c7f761f2d2fac77b",
+    "zh:d45e8bd98fc6752ea087e744efdafb209e7ec5a4224f9affee0a24fb51d26bb9",
+    "zh:d4739255076ed7f3ac2a06aef89e8e48a87667f3e470c514ce2185c0569cc1fb",
+    "zh:dbd2f11529a422ffd17040a70c0cc2802b7f1be2499e976dc22f1138d022b1b4",
+    "zh:dbd5357082b2485bb9978bce5b6d508d6b431d15c53bfa1fcc2781131826b5d8",
   ]
 }
 

--- a/k8s/tf/200_single_state/us-west-2/dns.tf
+++ b/k8s/tf/200_single_state/us-west-2/dns.tf
@@ -2,18 +2,17 @@ data "aws_route53_zone" "sumo_mozit_cloud" {
   name = "sumo.mozit.cloud"
 }
 
-# to be applied after EKS migration
-# data "aws_elb" "prod_oregon_sumo" {
-#   name = "afcd59e18d6334565b2eb1e439217b36"
-# }
+data "aws_elb" "prod_oregon_sumo" {
+  name = "afcd59e18d6334565b2eb1e439217b36"
+}
 
-# resource "aws_route53_record" "prod-oregon_sumo_mozit_cloud" {
-#   zone_id = data.aws_route53_zone.sumo_mozit_cloud.zone_id
-#   name    = "prod-oregon.sumo.mozit.cloud"
-#   type    = "CNAME"
-#   ttl     = "300"
-#   records = [data.aws_elb.prod_oregon_sumo.dns_name]
-# }
+resource "aws_route53_record" "prod-oregon_sumo_mozit_cloud" {
+  zone_id = data.aws_route53_zone.sumo_mozit_cloud.zone_id
+  name    = "prod-oregon.sumo.mozit.cloud"
+  type    = "CNAME"
+  ttl     = "60"
+  records = [data.aws_elb.prod_oregon_sumo.dns_name]
+}
 
 data "aws_elb" "stage_sumo" {
   name = "af66a7e87cd014b2e8a364f2ee250402"

--- a/k8s/tf/200_single_state/us-west-2/dns.tf
+++ b/k8s/tf/200_single_state/us-west-2/dns.tf
@@ -2,6 +2,19 @@ data "aws_route53_zone" "sumo_mozit_cloud" {
   name = "sumo.mozit.cloud"
 }
 
+# to be applied after EKS migration
+# data "aws_elb" "prod_oregon_sumo" {
+#   name = "afcd59e18d6334565b2eb1e439217b36"
+# }
+
+# resource "aws_route53_record" "prod-oregon_sumo_mozit_cloud" {
+#   zone_id = data.aws_route53_zone.sumo_mozit_cloud.zone_id
+#   name    = "prod-oregon.sumo.mozit.cloud"
+#   type    = "CNAME"
+#   ttl     = "300"
+#   records = [data.aws_elb.prod_oregon_sumo.dns_name]
+# }
+
 data "aws_elb" "stage_sumo" {
   name = "af66a7e87cd014b2e8a364f2ee250402"
 }

--- a/k8s/tf/200_single_state/us-west-2/traffic-policy.tf
+++ b/k8s/tf/200_single_state/us-west-2/traffic-policy.tf
@@ -33,7 +33,6 @@ resource "aws_cloudwatch_metric_alarm" "stage_lb_dns_name" {
   }
 }
 
-# to be done after migration
 resource "aws_route53_health_check" "prod" {
   fqdn              = "prod-oregon.sumo.mozit.cloud"
   port              = 443

--- a/k8s/tf/200_single_state/us-west-2/traffic-policy.tf
+++ b/k8s/tf/200_single_state/us-west-2/traffic-policy.tf
@@ -34,37 +34,37 @@ resource "aws_cloudwatch_metric_alarm" "stage_lb_dns_name" {
 }
 
 # to be done after migration
-#resource "aws_route53_health_check" "prod" {
-#  fqdn              = "prod-oregon.sumo.mozit.cloud"
-#  port              = 443
-#  type              = "HTTPS"
-#  resource_path     = "/readiness/"
-#  failure_threshold = "3"
-#  request_interval  = "30"
-#  enable_sni        = true
-#
-#  tags = {
-#    Name = "Sumo Prod us-west-2 EKS"
-#  }
-#}
-#
-#resource "aws_cloudwatch_metric_alarm" "prod_lb_dns_name" {
-#  provider            = aws.us-east-1
-#  alarm_name          = "Sumo_Prod_us-west-2-awsroute53"
-#  comparison_operator = "LessThanThreshold"
-#  evaluation_periods  = "1"
-#  metric_name         = "HealthCheckStatus"
-#  namespace           = "AWS/Route53"
-#  period              = "60"
-#  statistic           = "Minimum"
-#  threshold           = "1"
-#  treat_missing_data  = "missing"
-#  alarm_description   = "Monitor Prod EKS us-west-2 health"
-#
-#  actions_enabled = "true"
-#  alarm_actions   = ["arn:aws:sns:us-east-1:095732026120:MozillaSumoSlack"]
-#
-#  dimensions = {
-#    HealthCheckId = aws_route53_health_check.prod.id
-#  }
-#}
+resource "aws_route53_health_check" "prod" {
+  fqdn              = "prod-oregon.sumo.mozit.cloud"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/readiness/"
+  failure_threshold = "3"
+  request_interval  = "30"
+  enable_sni        = true
+
+  tags = {
+    Name = "Sumo Prod us-west-2 EKS"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "prod_lb_dns_name" {
+  provider            = aws.us-east-1
+  alarm_name          = "Sumo_Prod_us-west-2-awsroute53"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "1"
+  treat_missing_data  = "missing"
+  alarm_description   = "Monitor Prod EKS us-west-2 health"
+
+  actions_enabled = "true"
+  alarm_actions   = ["arn:aws:sns:us-east-1:095732026120:MozillaSumoSlack"]
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.prod.id
+  }
+}


### PR DESCRIPTION
Oregon prod: 
- Add Monitoring to DNS health check prod-oregon.sumo.mozit.cloud endpoint
- Add DNS Oregon to be applied after EKS migration