### PR TITLE
SE-3042 - Change prod rds to 31 days

### DIFF
--- a/k8s/tf/70_prod_db_redis/.terraform.lock.hcl
+++ b/k8s/tf/70_prod_db_redis/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.2.0"
+  hashes = [
+    "h1:7xPC2b+Plr514HPRf837t3YFzlSSIY03StrScaVIfw0=",
+    "zh:297d6462055eac8eb5c6735bd1a0fec23574e27d56c4c14a39efd8f3931ce4ed",
+    "zh:457319839adca3638fd76f49fd65e15756717f97ac99bd1805a1c9387a62a250",
+    "zh:57377384fa28abc4211a0916fc0fb590af238d096ad0490434ffeb89f568df9b",
+    "zh:578e1d21bd6d38bdaef0909b30959b884e84e6c464796a50e516822955db162a",
+    "zh:5e7ff13cc976f609aee4ada3c1967ba1f0ce5d276f3102a0aeaedc586d25ea80",
+    "zh:5e94f09fe1874a2365bd566fecab8f676cd720da1c0bf70875392679549ebf20",
+    "zh:93da14d7ffb8550b161cb79fe2cfc0f66848dd5022974399ae2bf88da7b9e9c5",
+    "zh:c51e4541f3d29627974dcb7f5919012a762391accb574ade9e28bdb3c92bada5",
+    "zh:eff58c1680e3f29e514919346d937bbe47278434ae03ed62443c77e878e267b1",
+    "zh:f2b749e6c6b77b26e643bbecc829977270cfefab106d5ea57e5a83e96d49cbdd",
+    "zh:fcc17e60e55c278535c332469727cf215eaea9ec81d38e2b5f05be127ee39a5b",
+  ]
+}

--- a/k8s/tf/70_prod_db_redis/main.tf
+++ b/k8s/tf/70_prod_db_redis/main.tf
@@ -22,7 +22,7 @@ module "mysql-prod" {
   mysql_instance_class              = "db.m5.4xlarge"
   mysql_backup_retention_days       = 31
   mysql_security_group_name         = "sumo_rds_sg_prod"
-  mysql_storage_gb                  = 250
+  mysql_storage_gb                  = 500
   mysql_storage_type                = "gp2"
   mysql_allow_major_version_upgrade = true
   mysql_engine_version = {

--- a/k8s/tf/70_prod_db_redis/main.tf
+++ b/k8s/tf/70_prod_db_redis/main.tf
@@ -20,7 +20,7 @@ module "mysql-prod" {
   mysql_password                    = var.mysql_prod_password
   mysql_identifier                  = "sumo"
   mysql_instance_class              = "db.m5.4xlarge"
-  mysql_backup_retention_days       = 14
+  mysql_backup_retention_days       = 31
   mysql_security_group_name         = "sumo_rds_sg_prod"
   mysql_storage_gb                  = 250
   mysql_storage_type                = "gp2"


### PR DESCRIPTION
Per our normal retention policy, keep backups for at least 30 days
using 31 to ensure we always have 30.