### PR TITLE
update cloudsql IP for migrating sumo data from dp2 to firefox.gcp

### DIFF
--- a/k8s/tf/70_prod_db_redis/variables.tf
+++ b/k8s/tf/70_prod_db_redis/variables.tf
@@ -10,6 +10,7 @@ variable "it_vpn_cidr" {
 variable "mysql_prod_password" {
 }
 
+# see https://github.com/mozilla-services/cloudops-infra/pull/4216
 variable "cloud_sql_cidr" {
-  default = "34.72.95.189/32"
+  default = "34.173.94.217/32"
 }


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/DSRE-719

What this PR does:
* updates the CloudSQL replication IP address from the one used formerly for replication to dp2 platform (in gcp.infra org) to one now setup for CloudSQL replication to a firefox.gcp, Data SRE backed infra

Related to: https://github.com/mozilla-services/cloudops-infra/pull/4216