### PR TITLE
update sumo database for prod & stage cloudsql replica

### DIFF
--- a/k8s/tf/70_prod_db_redis/data.tf
+++ b/k8s/tf/70_prod_db_redis/data.tf
@@ -20,7 +20,7 @@ data "aws_subnet_ids" "database" {
 
 data "aws_security_groups" "kops_sg" {
   filter {
-    name   = "group-name"
+    name = "group-name"
     values = [
       "nodes.k8s.${var.region}*.sumo.mozit.cloud",
       "eks-cluster-sg-sumo-eks-us-west-2-1883690534"

--- a/k8s/tf/70_prod_db_redis/rds-multi-az/rds-multi-az.tf
+++ b/k8s/tf/70_prod_db_redis/rds-multi-az/rds-multi-az.tf
@@ -55,7 +55,7 @@ resource "aws_security_group" "sumo_rds_sg" {
     from_port   = var.mysql_port
     to_port     = var.mysql_port
     protocol    = "TCP"
-    cidr_blocks = [var.vpc_cidr, var.it_vpn_cidr, var.cloud_sql_cidr]
+    cidr_blocks = concat([var.vpc_cidr, var.it_vpn_cidr], var.cloud_sql_cidr)
   }
 
   egress {

--- a/k8s/tf/70_prod_db_redis/rds-multi-az/variables.tf
+++ b/k8s/tf/70_prod_db_redis/rds-multi-az/variables.tf
@@ -86,5 +86,6 @@ variable "it_vpn_cidr" {
 }
 
 variable "cloud_sql_cidr" {
-  description = "IP address of Cloud SQL replica"
+  description = "IP addresses of Cloud SQL replicas of SUMO Database. See https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=169419933"
+  type        = list(string)
 }

--- a/k8s/tf/70_prod_db_redis/variables.tf
+++ b/k8s/tf/70_prod_db_redis/variables.tf
@@ -12,5 +12,10 @@ variable "mysql_prod_password" {
 
 # see https://github.com/mozilla-services/cloudops-infra/pull/4216
 variable "cloud_sql_cidr" {
-  default = "34.173.94.217/32"
+  default = [
+    "34.168.73.11/32", # prod
+    "35.247.21.66/32"  # stage
+  ]
+  description = "IP addresses of Cloud SQL replicas of SUMO Database. See https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=169419933"
+  type        = list(string)
 }


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/DSRE-719 follow-up

What this PR does:
* updates #93 
* the cloudsql replica in data-sumo prod updated, changing its ip
* we'd like to setup a stage data-sumo project where the developers can work on queries and such, hence the addition of the stage ip for a second replica - why not connect the stage data-sumo project to the stage database? we thought about it, but the stage environment is meant to work with production data but for stage queries, views, dashboards - if that makes sense. Open to discussion on this though.

Next steps:
* someone on Web SRE will need to tf plan & apply this for me; I've done everything on the GCP side.